### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ make docs
 
 [build-status-image]: https://secure.travis-ci.org/arve0/microscopestitching.png?branch=master
 [travis]: http://travis-ci.org/arve0/microscopestitching?branch=master
-[pypi-version]: https://pypip.in/version/microscopestitching/badge.svg
+[pypi-version]: https://img.shields.io/pypi/v/microscopestitching.svg
 [pypi]: https://pypi.python.org/pypi/microscopestitching
-[wheel]: https://pypip.in/wheel/microscopestitching/badge.svg
+[wheel]: https://img.shields.io/pypi/wheel/microscopestitching.svg


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20microscopestitching))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `microscopestitching`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.